### PR TITLE
[PR] Don't schedule an event if one is already scheduled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "wsu-university-taxonomy",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wsu-university-taxonomy",
-	"version": "0.4.5",
+	"version": "0.4.6",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/washingtonstateuniversity/wsu-university-taxonomy.git"

--- a/wsuwp-university-taxonomies.php
+++ b/wsuwp-university-taxonomies.php
@@ -1,7 +1,7 @@
 <?php
 /*
 Plugin Name: WSUWP University Taxonomies
-Version: 0.4.5
+Version: 0.4.6
 Plugin URI: https://web.wsu.edu/
 Description: Provides Washington State University taxonomies to WordPress
 Author: washingtonstateuniversity, jeremyfelt, philcable

--- a/wsuwp-university-taxonomies.php
+++ b/wsuwp-university-taxonomies.php
@@ -72,7 +72,7 @@ class WSUWP_University_Taxonomies {
 	public function check_schema() {
 		if ( get_option( 'wsu_taxonomy_schema', false ) !== $this->taxonomy_schema_version ) {
 			// Don't schedule a duplicate event if one has already been scheduled.
-			$next = wp_next_scheduled( $hook, $args );
+			$next = wp_next_scheduled( 'wsu_taxonomy_update_schema', array() );
 			if ( $next ) {
 				return;
 			}

--- a/wsuwp-university-taxonomies.php
+++ b/wsuwp-university-taxonomies.php
@@ -73,7 +73,7 @@ class WSUWP_University_Taxonomies {
 		if ( get_option( 'wsu_taxonomy_schema', false ) !== $this->taxonomy_schema_version ) {
 			// Don't schedule a duplicate event if one has already been scheduled.
 			$next = wp_next_scheduled( $hook, $args );
-			if ( $next )  {
+			if ( $next ) {
 				return;
 			}
 

--- a/wsuwp-university-taxonomies.php
+++ b/wsuwp-university-taxonomies.php
@@ -71,6 +71,12 @@ class WSUWP_University_Taxonomies {
 	 */
 	public function check_schema() {
 		if ( get_option( 'wsu_taxonomy_schema', false ) !== $this->taxonomy_schema_version ) {
+			// Don't schedule a duplicate event if one has already been scheduled.
+			$next = wp_next_scheduled( $hook, $args );
+			if ( $next )  {
+				return;
+			}
+
 			wp_schedule_single_event( time() + 60, 'wsu_taxonomy_update_schema' );
 		}
 	}


### PR DESCRIPTION
If our cron runner is paused or stopped after crashing in the middle of the night, these scheduled events stack up quickly.