### PR TITLE
[PR] Add Education and rename Spokane

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wsu-university-taxonomy",
-	"version": "0.4.12",
+	"version": "0.5.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/washingtonstateuniversity/wsu-university-taxonomy.git"

--- a/wsuwp-university-taxonomies.php
+++ b/wsuwp-university-taxonomies.php
@@ -653,8 +653,9 @@ class WSUWP_University_Taxonomies {
 					'Women\'s Studies Program',
 				),
 				'College of Education' => array(
-					'Educational Leadership, Sports Studies, and Educational / Counseling Psychology',
+					'Educational Leadership and Sport Management',
 					'Teaching and Learning',
+					'Kinesiology and Educational Psychology',
 				),
 				'Elson S. Floyd College of Medicine' => array(
 					'Biomedical Sciences',
@@ -705,7 +706,7 @@ class WSUWP_University_Taxonomies {
 		$locations = array(
 			'WSU Pullman'                      => array(),
 			'WSU West/Downtown Seattle'        => array(),
-			'WSU Spokane'                      => array(),
+			'WSU Health Sciences Spokane'      => array(),
 			'WSU Tri-Cities'                   => array(),
 			'WSU Vancouver'                    => array(),
 			'WSU Global Campus'                => array(),


### PR DESCRIPTION
## Updated
- Changed Educational Leadership, Sport Studies, and Educational/Counseling Psychology to Educational Leadership and Sport Management
- Renamed WSU Spokane to WSU Health Sciences Spokane

## Added
- Added Kinesiology and Educational Psychology